### PR TITLE
Bump bitvec dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitvec = "0.22"
+bitvec = "1.0.1"
 nalgebra = { version = "0.28", optional = true }
 
 [features]

--- a/src/tpntree/mod.rs
+++ b/src/tpntree/mod.rs
@@ -111,7 +111,7 @@ impl<T, const N: usize> TpnTree<T, N> {
                 children.push(Self::new(coordinates, span, self.level + 1));
 
                 let mut carry = pattern.clone();
-                carry.set_all(false);
+                carry.set_elements(0);
                 let mut one = carry.clone();
                 one.set(0, true);
 

--- a/src/tpntree_dynamic/mod.rs
+++ b/src/tpntree_dynamic/mod.rs
@@ -111,7 +111,7 @@ impl<T> TpnTree<T> {
                 children.push(Self::new(coordinates, span, self.level + 1));
 
                 let mut carry = pattern.clone();
-                carry.set_all(false);
+                carry.set_elements(0);
                 let mut one = carry.clone();
                 one.set(0, true);
 


### PR DESCRIPTION
Hello,

I tried to use this package on crates.io but got this error
```
$ cargo build
    Updating crates.io index
error: failed to select a version for the requirement `funty = "~1.2"`
candidate versions found which didn't match: 2.0.0, 1.1.0, 1.0.1, ...
location searched: crates.io index
required by package `bitvec v0.22.0`
    ... which satisfies dependency `bitvec = "^0.22"` of package `tpntree v0.5.1 (.../tpntree)`
```

I bumped the bitvec dependency and checked that the tests still pass
```
$ cargo test
   Compiling tpntree v0.5.1 (.../tpntree)
warning: unused return value of `Option::<T>::insert` that must be used
  --> src/tpntree/iterators.rs:42:13
   |
42 |             child.data_mut().insert(2.0);
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: if you intended to set a value, consider assignment instead
   = note: `#[warn(unused_must_use)]` on by default

warning: unused return value of `Option::<T>::insert` that must be used
  --> src/tpntree/iterators.rs:47:13
   |
47 |             child.data_mut().insert(3.0);
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: if you intended to set a value, consider assignment instead

warning: `tpntree` (lib test) generated 2 warnings
    Finished test [unoptimized + debuginfo] target(s) in 1.34s
     Running unittests src/lib.rs (target/debug/deps/tpntree-828eaaa4c613f98e)

running 22 tests
test tpntree::nalgebra::tests::calculate_variance_alone ... ok
test tpntree::spatial::tests::insert_into_root ... ok
test tpntree::spatial::tests::tree_contains_coordinates ... ok
test tpntree::spatial::tests::tree_does_not_contain_coordinates ... ok
test tpntree::nalgebra::tests::calculate_variance_with_children ... ok
test tpntree::tests::divide_into_subregions_dim_1 ... ok
test tpntree::tests::get_adjacent_trees_dimension_one ... ok
test tpntree::iterators::tests::iterate_depth_first ... ok
test tpntree::iterators::tests::iterate_breadth_first ... ok
test tpntree::tests::get_adjacent_trees_dimension_two ... ok
test tpntree::spatial::tests::insert_and_split ... ok
test tpntree_dynamic::nalgebra::tests::calculate_variance_alone ... ok
test tpntree::tests::divide_into_subregions_dim_2 ... ok
test tpntree::tests::divide_into_subregions_dim_3 ... ok
test tpntree_dynamic::tests::divide_into_subregions_dim_1 ... ok
test tpntree_dynamic::nalgebra::tests::calculate_variance_with_children ... ok
test tpntree_dynamic::tests::get_adjacent_trees_dimension_one ... ok
test tpntree_dynamic::tests::get_adjacent_trees_dimension_two ... ok
test tpntree_dynamic::iterators::tests::iterate_depth_first ... ok
test tpntree_dynamic::tests::divide_into_subregions_dim_2 ... ok
test tpntree_dynamic::tests::divide_into_subregions_dim_3 ... ok
test tpntree_dynamic::iterators::tests::iterate_breadth_first ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests tpntree

running 11 tests
test src/tpntree/mod.rs - tpntree::TpnTree<T,N>::new (line 45) ... ok
test src/tpntree/mod.rs - tpntree::TpnTree<T,N>::root (line 67) ... ok
test src/tpntree/mod.rs - tpntree::TpnTree<T,N>::new (line 36) ... ok
test src/tpntree/spatial.rs - tpntree::spatial::SpatialTree<T,N>::spans (line 15) ... ok
test src/tpntree_dynamic/mod.rs - tpntree_dynamic::TpnTree<T>::new (line 32) ... ok
test src/tpntree_dynamic/mod.rs - tpntree_dynamic::TpnTree<T>::new (line 41) ... ok
test src/tpntree_dynamic/mod.rs - tpntree_dynamic::TpnTree<T>::root (line 67) ... ok
test src/tpntree_dynamic/mod.rs - tpntree_dynamic::TpnTree<T>::divide (line 89) ... ok
test src/tpntree/spatial.rs - tpntree::spatial::SpatialTree<T,N>::insert_by_coordinates (line 42) ... ok
test src/tpntree/mod.rs - tpntree::TpnTree<T,N>::divide (line 86) ... ok
test src/tpntree/spatial.rs - tpntree::spatial::SpatialTree<T,N>::find_by_coordinates (line 98) ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.06s
```
